### PR TITLE
added missing command value to aliases

### DIFF
--- a/AliasFunctions.go
+++ b/AliasFunctions.go
@@ -32,6 +32,9 @@ func handleAliases(aliasList *[]Alias, parentDir string) {
 
 	jsonFilePath := filepath.Join(parentDir, "aliases.json")
 	jsonData, err := json.MarshalIndent(jsonFile, "", "       ")
+	if err != nil {
+		panic(err)
+	}
 	err = os.WriteFile(jsonFilePath, jsonData, 0644)
 	if err != nil {
 		panic(err)

--- a/AliasModel.go
+++ b/AliasModel.go
@@ -16,6 +16,7 @@ type Alias struct {
 	Name       string       `xml:"name" json:"name"`
 	Regex      string       `xml:"regex" json:"regex,omitempty"`
 	Script     string       `xml:"script" json:"script"`
+	Command    string       `xml:"command" json:"command,omitempty"`
 	AliasList  []Alias      `xml:"Alias" json:"-"`
 	AliasGroup []AliasGroup `xml:"AliasGroup" json:"-"`
 }


### PR DESCRIPTION
Noticed aliases that were just commands were not getting correctly created. Fixed by adding the command value in.
Additional small fix to capture the err state of json.MarshalIndent.