### PR TITLE
Add support for trigger chains and filter chains

### DIFF
--- a/XMLHelper.go
+++ b/XMLHelper.go
@@ -38,8 +38,7 @@ func handleXML(f *zip.File, baseDir string) {
 					panic(err)
 				}
 				localBaseDir := filepath.Join(baseDir, "triggers")
-				handleTriggerGroups(&triggerPackage.TriggerGroup, localBaseDir)
-				handleTriggers(&triggerPackage.Triggers, localBaseDir)
+				handleTriggerPackage(&triggerPackage.TriggerGroup, &triggerPackage.Triggers, localBaseDir)
 			case "ScriptPackage":
 				err = decoder.DecodeElement(&scriptPackage, &se)
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,11 @@ import (
 
 func containsIllegalCharacters(filename string) bool {
 	illegalCharacters := []rune{'<', '>', ':', '"', '/', '\\', '|', '?', '*'}
-	return strings.ContainsAny(filename, string(illegalCharacters))
+	result := strings.ContainsAny(filename, string(illegalCharacters))
+	if result {
+		fmt.Printf("warn: file %s contains illegal characters, consider changing its name.\n", filename)
+	}
+	return result
 }
 
 func main() {


### PR DESCRIPTION
Previously, filter and trigger chains were getting lost during demuddling because there was no support for writing out the `Trigger` properties of `TriggerGroup` when there was a trigger pattern set. 

These changes correctly capture chains into a format that muddler can successfully muddle. 
However, I found the implementation of this a little tricky -- there's almost certainly opportunities for refactoring here.

Also included in this PR is a small change to warn when a filename contains illegal characters instead of failing silently.
