### PR TITLE
Fix multilineDelta

### DIFF
--- a/TriggerModel.go
+++ b/TriggerModel.go
@@ -48,7 +48,7 @@ type JSONTrigger struct {
 	IsFolder       string        `json:"isFolder"`
 	Command        string        `json:"command,omitempty"`
 	Multiline      string        `json:"multiline"`
-	MultilineDelta string        `json:"multielineDelta"`
+	MultilineDelta string        `json:"multilineDelta"`
 	Matchall       string        `json:"matchall"`
 	Filter         string        `json:"filter"`
 	FireLength     string        `json:"fireLength"`


### PR DESCRIPTION
There was a typo on the Muddler wiki (now fixed) that put an extra 'e' in the key. This fixes DeMuddler to use the expected value for multilineDelta