### PR TITLE
Fix issue with nested folders

### DIFF
--- a/KeyFunctions.go
+++ b/KeyFunctions.go
@@ -60,7 +60,7 @@ func handleKeyGroups(groups *[]KeyEntity, baseDir string, seenNames map[string]b
 	}
 }
 
-func convertKeyCodes(key *KeyEntity){
+func convertKeyCodes(key *KeyEntity) {
 	var pressedKeys []string
 	for _, mod := range keyModifiers {
 		value, err := strconv.ParseInt(key.KeyModifier, 10, 32)

--- a/handleUtils.go
+++ b/handleUtils.go
@@ -23,7 +23,16 @@ func writeJsonToFilewriteJsonToFile[T JSONSerializable](data *[]T, parentDir, fi
 	}
 
 	jsonFilePath := filepath.Join(parentDir, fileName)
-	jsonData, err := json.MarshalIndent(data, "", "       ")
+
+	// Read previous data, if any
+	var prev []T
+	prevData, err := os.ReadFile(jsonFilePath)
+	if err == nil {
+		json.Unmarshal(prevData, &prev)
+	}
+
+	finalData := append(prev, *data...)
+	jsonData, err := json.MarshalIndent(finalData, "", "       ")
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,14 +5,14 @@ import (
 )
 
 func main() {
-    filePath := parseFlags()
-    validateFilePath(filePath)
-    r := openZipFile(filePath)
-    defer r.Close()
+	filePath := parseFlags()
+	validateFilePath(filePath)
+	r := openZipFile(filePath)
+	defer r.Close()
 
-    workDir := getWorkingDirectory()
-    fileName := extractFileName(filePath)
+	workDir := getWorkingDirectory()
+	fileName := extractFileName(filePath)
 
-    baseDir := filepath.Join(workDir, fileName, "src")
-    processZipFiles(r, baseDir, workDir, fileName)
+	baseDir := filepath.Join(workDir, fileName, "src")
+	processZipFiles(r, baseDir, workDir, fileName)
 }


### PR DESCRIPTION
## Overview
- Before (over)writing a new `scripts.json`, read and include any
  previous data from the preexisting file, if present.
- This seems to fix the issue of folders including both subfolders and normal
  elements not properly rebuilding when repackaging via `muddle`.

Example package structure used  to test and implement the fix. Before the fix, `script 3` was missing from 
the `Nested 2` folder as the `scripts.json` was overwritten when handling the `Inner` folder.
![priFw6L](https://github.com/user-attachments/assets/ad7b75cc-90a9-4417-b5df-47a1f7a1bcd6)

## Testing
- Rename [test.zip](https://github.com/user-attachments/files/18396253/test.zip) to `test.mpackage`
- Add it as a package to Mudlet
- run latest DeMuddler on it
- run Muddler inside the resulting `test` folder
- Add the resulting package (test/build/test.mpackage) to Mudlet
- Compare the two packages and verify that `Test/Nested 2/script 3` is missing
- Rebuild DeMuddler with the updates from this PR, de-muddle and rebuild the test package again
- Compare the new package with the original one