### PR TITLE
Fix JSON duplication bug when running DeMuddler multiple times

### DIFF
--- a/AliasFunctions.go
+++ b/AliasFunctions.go
@@ -16,7 +16,7 @@ func writeAliasList(aliasList *[]AliasEntity, parentDir string, seenNames map[st
 }
 
 func writeAliasJson(aliasList *[]AliasEntity, parentDir string) {
-	writeJsonToFilewriteJsonToFile(aliasList, parentDir, "aliases.json")
+	writeJsonToFile(aliasList, parentDir, "aliases.json")
 }
 
 func handleAliases(aliasList *[]AliasEntity, parentDir string, seenNames map[string]bool) {

--- a/KeyFunctions.go
+++ b/KeyFunctions.go
@@ -24,7 +24,7 @@ func writeKeyJson(keys *[]KeyEntity, parentDir string) {
 		key := &(*keys)[i]
 		convertKeyCodes(key)
 	}
-	writeJsonToFilewriteJsonToFile(keys, parentDir, "keys.json")
+	writeJsonToFile(keys, parentDir, "keys.json")
 }
 
 func handleKeys(keys *[]KeyEntity, parentDir string, seenNames map[string]bool) {

--- a/ScriptFunctions.go
+++ b/ScriptFunctions.go
@@ -16,7 +16,7 @@ func writeScripts(scripts *[]ScriptEntity, parentDir string, seenNames map[strin
 }
 
 func writeScriptJson(scripts *[]ScriptEntity, parentDir string) {
-	writeJsonToFilewriteJsonToFile(scripts, parentDir, "scripts.json")
+	writeJsonToFile(scripts, parentDir, "scripts.json")
 }
 
 func handleScripts(scripts *[]ScriptEntity, parentDir string, seenNames map[string]bool) {

--- a/TimerFunctions.go
+++ b/TimerFunctions.go
@@ -23,7 +23,7 @@ func writeTimerJson(timers *[]TimerEntity, parentDir string) {
 		timer := &(*timers)[i]
 		ConvertTimeToSingleProperties(timer)
 	}
-	writeJsonToFilewriteJsonToFile(timers, parentDir, "timers.json")
+	writeJsonToFile(timers, parentDir, "timers.json")
 }
 
 func handleTimers(timers *[]TimerEntity, parentDir string, seenNames map[string]bool) {

--- a/handleUtils.go
+++ b/handleUtils.go
@@ -17,22 +17,14 @@ type ScriptHandler interface {
 	SetScript(script string)
 }
 
-func writeJsonToFilewriteJsonToFile[T JSONSerializable](data *[]T, parentDir, fileName string) {
+func writeJsonToFile[T JSONSerializable](data *[]T, parentDir, fileName string) {
 	if len(*data) == 0 {
 		return
 	}
 
 	jsonFilePath := filepath.Join(parentDir, fileName)
 
-	// Read previous data, if any
-	var prev []T
-	prevData, err := os.ReadFile(jsonFilePath)
-	if err == nil {
-		json.Unmarshal(prevData, &prev)
-	}
-
-	finalData := append(prev, *data...)
-	jsonData, err := json.MarshalIndent(finalData, "", "       ")
+	jsonData, err := json.MarshalIndent(data, "", "       ")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary
This PR fixes a bug where running DeMuddler multiple times on the same `.mpackage` file would duplicate entries in the generated JSON files (aliases.json, scripts.json, keys.json, timers.json).

## Problem
The `writeJsonToFilewriteJsonToFile` function in `handleUtils.go` was reading existing JSON files and appending new data instead of overwriting them. This caused data to be duplicated with each subsequent run on the same .mpackage file.

## Solution
- Removed the append logic that read and merged previous JSON data
- Simplified the function to directly write the new data
- Fixed function name typo: `writeJsonToFilewriteJsonToFile` → `writeJsonToFile`
- Updated all call sites in:
  - `AliasFunctions.go`
  - `ScriptFunctions.go`
  - `KeyFunctions.go`
  - `TimerFunctions.go`

## Testing
Verified by running DeMuddler twice on the same `.mpackage` file and confirming that JSON files maintain the same content (no duplicates) after the second run.

**Before fix:** Second run would double the entries in JSON files  
**After fix:** Second run correctly overwrites with the same data

## Changes
- Modified 5 files
- Removed 14 lines, added 6 lines
- Net reduction of 8 lines (simplified logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)